### PR TITLE
prep to publish 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.1-dev
+## 1.2.1
 
 * Migrate to `package:lints`.
 * Populate the pubspec `repository` field.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Dart CI](https://github.com/dart-lang/term_glyph/actions/workflows/test-package.yml/badge.svg)](https://github.com/dart-lang/term_glyph/actions/workflows/test-package.yml)
+[![pub package](https://img.shields.io/pub/v/term_glyph.svg)](https://pub.dev/packages/term_glyph)
+[![package publisher](https://img.shields.io/pub/publisher/term_glyph.svg)](https://pub.dev/packages/term_glyph/publisher)
+
 This library contains getters for useful Unicode glyphs as well as plain ASCII
 alternatives. It's intended to be used in command-line applications that may run
 in places where Unicode isn't well-supported and libraries that may be used by

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: term_glyph
-version: 1.2.1-dev
+version: 1.2.1
 description: Useful Unicode glyphs and ASCII substitutes.
 repository: https://github.com/dart-lang/term_glyph
 


### PR DESCRIPTION
- prep to publish 1.2.1
- update the package's markdown badges
